### PR TITLE
Fix `pip install` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Other useful external programs needed for full functionality include:
 Download and install git (If you have not already): [git installation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 ```bash
-pip install git+[https://github.com/ciresdem/cudem.git#egg=cudem](https://github.com/ciresdem/cudem.git#egg=cudem)
+pip install git+https://github.com/ciresdem/cudem.git#egg=cudem
 
 ```
 


### PR DESCRIPTION
The current command's URL seems to have been converted to a Markdown link so copy/pasting it doesn't work as expected!

Introduced in commit: https://github.com/ciresdem/cudem/commit/8e276f56445d3a663150664fe399f52a5ad14d48